### PR TITLE
Adds the ruby icon to .rb files

### DIFF
--- a/icon_ruby.tmPreferences
+++ b/icon_ruby.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.haml,source.ruby.rails</string>
+    <string>source.ruby,source.haml,source.ruby.rails</string>
     <key>settings</key>
     <dict>
         <key>icon</key>


### PR DESCRIPTION
source.ruby was missing from the icon_ruby.tmPreferences file.

![screen shot 2014-08-26 at 21 46 37](https://cloud.githubusercontent.com/assets/968731/4051516/36cd41b8-2d62-11e4-8df4-1e391547103f.png)
