### PR TITLE
Fixing Rust Scope

### DIFF
--- a/icon_rust.tmPreferences
+++ b/icon_rust.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.rs</string>
+    <string>source.rust</string>
     <key>settings</key>
     <dict>
         <key>icon</key>


### PR DESCRIPTION
This should fix the scope for rust.

Using Scope Hunter inside of a Rust function it output.
`Scope:                    source.rust`
