### PR TITLE
Add style to tab_label transient

### DIFF
--- a/Seti.sublime-theme
+++ b/Seti.sublime-theme
@@ -169,6 +169,11 @@
         "parents": [{"class": "tab_control","attributes": ["selected"]}],
         "fg": [223,225,232]
     },
+    {
+        "class": "tab_label",
+        "parents": [{"class": "tab_control","attributes": ["transient"]}],
+        "font.italic": true
+    },
 
 //========================================================
 //  TAB SCROLLING


### PR DESCRIPTION
Seti_Ui is a pretty theme! Only one thing was missing in it:

If you give a single click on a file on sidebar, the opened tab label doesn't stay with italic style.
Now this works:

![set_label-transient](https://cloud.githubusercontent.com/assets/487669/6407278/8999f720-be1b-11e4-8dd4-13ad94623eb9.png)