### PR TITLE
improves es6 highlight

### DIFF
--- a/Scheme/Seti_monokai.tmTheme
+++ b/Scheme/Seti_monokai.tmTheme
@@ -198,7 +198,7 @@
                 <key>name</key>
                 <string>Function name</string>
                 <key>scope</key>
-                <string>entity.name.function</string>
+                <string>entity.name.function, entity.name.method</string>
                 <key>settings</key>
                 <dict>
                     <key>fontStyle</key>
@@ -276,7 +276,7 @@
                 <key>name</key>
                 <string>Library class/type</string>
                 <key>scope</key>
-                <string>support.type, support.class</string>
+                <string>support.type, support.class, variable.language</string>
                 <key>settings</key>
                 <dict>
                     <key>fontStyle</key>


### PR DESCRIPTION
Hi,

Using [babel-sublime](https://github.com/babel/babel-sublime) for ES6 JavaScript highlight + Seti_monokai.theme is missing highlight for `entity.name.method` and `variable.language`:
![before](https://cloud.githubusercontent.com/assets/680356/6647330/068f881c-c9ac-11e4-8c75-6e9dffe87c5d.png)

With these changes the result is this one:

![after](https://cloud.githubusercontent.com/assets/680356/6647335/0e27e416-c9ac-11e4-8555-ece7b4ffdb07.png)

Cheers,