### PR TITLE
Fix support to detect gulpfile.babel.js

### DIFF
--- a/Langs/Gruntfile JS.tmLanguage
+++ b/Langs/Gruntfile JS.tmLanguage
@@ -7,7 +7,6 @@
 	<key>fileTypes</key>
 	<array>
 		<string>gruntfile.js</string>
-		<string>gruntfile.babel.js</string>
 	</array>
 	<key>patterns</key>
 	<array>

--- a/Langs/Gulpfile JS.tmLanguage
+++ b/Langs/Gulpfile JS.tmLanguage
@@ -7,6 +7,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>gulpfile.js</string>
+		<string>gulpfile.babel.js</string>
 	</array>
 	<key>patterns</key>
 	<array>


### PR DESCRIPTION
Sorry @ctf0, I accidentally add support to `gruntfile.babel.js` instead of `gulpfile.babel.js` at https://github.com/ctf0/Seti_ST3/pull/146. Grunt currently does not support Babel so I remove those lines.