### PR TITLE
Add variable.language to Seti_monokai.tmTheme

### DIFF
--- a/Scheme/Seti_monokai.tmTheme
+++ b/Scheme/Seti_monokai.tmTheme
@@ -276,7 +276,7 @@
                 <key>name</key>
                 <string>Library class/type</string>
                 <key>scope</key>
-                <string>support.type, support.class</string>
+                <string>support.type, support.class, variable.language</string>
                 <key>settings</key>
                 <dict>
                     <key>fontStyle</key>


### PR DESCRIPTION
The scope "variable.language" was removed in the latest version. In python, this causes the "self" variable/parameter (in class' methods) to be rendered in "white" instead of "blue", as previous versions.