### PR TITLE
Update Line Highlight Colour to match Sidebar

### DIFF
--- a/Scheme/Seti.tmTheme
+++ b/Scheme/Seti.tmTheme
@@ -22,7 +22,7 @@
                     <key>invisibles</key>
                     <string>#F3FFB51A</string>
                     <key>lineHighlight</key>
-                    <string>#101112</string>
+                    <string>#1B1C1D</string>
 
                     <key>findHighlight</key>
                     <string>#4FA5C7</string>


### PR DESCRIPTION

![clipboard01](https://cloud.githubusercontent.com/assets/1768449/8395533/687caf3a-1db4-11e5-8e18-c91ce75c8180.png)
Sidebar highlight colour in Seti_UI theme is easier to read than the line highlight in the Seti colour scheme. Updated to match.
Source: Seti.sublime-theme
```
    // Sidebar rows || selected files bg
    {
        "class": "tree_row",
        "layer0.texture": null,
        "layer0.tint": [27, 28, 29],
        "layer0.opacity": 0
    },
```