### PR TITLE
Remove row padding setting from Seti_show_group_arrows

### DIFF
--- a/Seti.sublime-theme
+++ b/Seti.sublime-theme
@@ -848,7 +848,6 @@
     {
         "class": "sidebar_tree",
         "settings": ["Seti_show_group_arrows"],
-        "row_padding": [8,7],
         "indent": 15,
         "indent_offset": 18,
     },

--- a/Seti_orig.sublime-theme
+++ b/Seti_orig.sublime-theme
@@ -786,7 +786,6 @@
     {
         "class": "sidebar_tree",
         "settings": ["Seti_show_group_arrows"],
-        "row_padding": [8,7],
         "indent": 15,
         "indent_offset": 18,
     },


### PR DESCRIPTION
Sidebar row padding should be set independent of the `Seti_show_group_arrows` setting. Currently, enabling this option overrides the `Seti_sb_small_padding` and `Seti_sb_big_padding` settings. This update removes the `row_padding` setting for `Seti_show_group_arrows` in `Seti.sublime-theme` and `Seti_orig.sublime-theme`.