### PR TITLE
Restore hover highlighting for all tab labels

### DIFF
--- a/Seti.sublime-theme
+++ b/Seti.sublime-theme
@@ -197,7 +197,7 @@
     },
     {
         "class": "tab_label",
-        "parents": [{"class": "tab_control", "attributes": ["hover", "selected"]}],
+        "parents": [{"class": "tab_control", "attributes": ["hover"]}],
         "fg": [255, 255, 255],
         "font.bold": false
     },

--- a/Seti_orig.sublime-theme
+++ b/Seti_orig.sublime-theme
@@ -146,7 +146,7 @@
     },
     {
         "class": "tab_label",
-        "parents": [{"class": "tab_control", "attributes": ["hover", "selected"]}],
+        "parents": [{"class": "tab_control", "attributes": ["hover"]}],
         "fg": [255, 255, 255],
         "font.bold": false
     },


### PR DESCRIPTION
Previous versions of the theme highlighted tab labels on hover for both selected and unselected tabs. This request restores that functionality.