### PR TITLE
Add option for disabling the min width for a tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Activate the `Theme` by modifying your user preferences file, which you can find
   "Seti_no_blue_bar": true,               // remove the blue bar under the un-saved tabs
   "Seti_tabs_small": true,                // tabs height = 35
   "Seti_tabs_med": true,                  // tabs height = 40
+  "Seti_tabs_no_min_width": true,         // disable min width for tabs (issues/223)
   "Seti_tab_font_12": true,               // tab font size = 12
   "mouse_wheel_tabswitch": true,          // scroll through opened tabs
   "Seti_no_scroll_icons": true,           // remove the l/r arrows & the drop down button, effective when ("enable_tab_scrolling": true)

--- a/Seti.sublime-theme
+++ b/Seti.sublime-theme
@@ -23,6 +23,11 @@
         "settings": ["mouse_wheel_tabswitch"],
         "mouse_wheel_switch": true
     },
+    {
+        "class": "tabset_control",
+        "settings": ["Seti_tabs_no_min_width"],
+        "tab_min_width": 0
+    },
 
     // Tab element
     {

--- a/Seti_orig.sublime-theme
+++ b/Seti_orig.sublime-theme
@@ -31,6 +31,11 @@
         "settings": ["Seti_tabs_med"],
         "tab_height": 40
     },
+    {
+        "class": "tabset_control",
+        "settings": ["Seti_tabs_no_min_width"],
+        "tab_min_width": 0
+    },
 
     // Tab element
     {


### PR DESCRIPTION
Fixes https://github.com/ctf0/Seti_ST3/issues/223

Might not be the most appropriate option name, feel free to change it.

I'm attaching a screenshot again, just to show you how it looks like when the option is on:

![screenshot from 2016-01-13 16 10 16](https://cloud.githubusercontent.com/assets/1694112/12296484/988a8442-ba10-11e5-8a76-e65282341c40.png)

That's exactly what I want - all tabs are visible!
