### PR TITLE
Fixes barely visible scrollbar "puck".

### DIFF
--- a/Seti.sublime-theme
+++ b/Seti.sublime-theme
@@ -392,7 +392,7 @@
     // Standard vertical scroll puck
     {
         "class": "puck_control",
-        "layer0.tint":[22,31,39],
+        "layer0.tint":[65,69,50],
         "layer0.opacity": 1,
         "layer0.inner_margin": 0,
         "content_margin": [3,0],
@@ -402,7 +402,7 @@
     {
         "class": "puck_control",
         "attributes": ["horizontal"],
-        "layer0.tint":[22,31,39],
+        "layer0.tint":[65,69,50],
         "layer0.inner_margin": 0,
         "content_margin": [12,3],
         "blur": false


### PR DESCRIPTION
Default color of the vertical/horizontal scrollbars "puck" (22,31,39) is very hard to see, specially when using an editor theme with a dark background (like Monokai - 39,40,34). It gets much more visible with color 65,69,50, which is the color used for this control on Seti for Atom (see attached Atom screenshot).
![atom_seti](https://cloud.githubusercontent.com/assets/4016782/18007913/56326b96-6b7c-11e6-8ff5-84746e6df122.png)

Fixes barely visible scrollbar "puck", using correct Seti color