### PR TITLE
Color title bar (OSX>=10.10) same as tabset-background w/option to not

### DIFF
--- a/Seti.sublime-theme
+++ b/Seti.sublime-theme
@@ -3335,5 +3335,13 @@
         "parents": [{ "class": "tree_row", "attributes": ["expanded"]}],
         "layer0.texture": "Seti_UI/Main/folder@2x.png",
         "content_margin": 8
-    }
+    },
+
+    // app title bar
+    {
+        "class": "title_bar",
+        "settings": ["!Seti_use_system_title_bar"],
+        "fg": [255, 255, 255],
+        "bg": [24, 29, 34]
+   }
 ]

--- a/Seti_orig.sublime-theme
+++ b/Seti_orig.sublime-theme
@@ -3980,5 +3980,13 @@
         "parents": [{"class": "tree_row","attributes": ["hover","selected"]}],
         "layer0.texture": "Seti_UI/Main/close@2x.png",
         "layer0.opacity": { "target": 1.0, "speed": 10.0, "interpolation": "smoothstep" },
-    }
+    },
+
+    // app title bar
+    {
+        "class": "title_bar",
+        "settings": ["!Seti_use_system_title_bar"],
+        "fg": [255, 255, 255],
+        "bg": [24, 29, 34]
+   }
 ]


### PR DESCRIPTION
 #295 
This takes advantage of the sublime text's new "title_bar" class in the theme engine which allows for customization of the window's title bar foreground and background colors. This patch changes the default behavior of both Seti and Seti_org themes to color the window title bar the same color as the tabset-background. Also added is the ability to override this by setting the option 
```json
"Seti_use_system_title_bar": true
```
.
I did not document this feature as it will only affect sublime users on dev builds >=3127 (i.e. those who have bought a license). Since I assume the majority of ST users are not using the dev build, I also assumed that documenting this feature would lead to more traffic towards the maintainer than was worth his time:)